### PR TITLE
feat: add destroy targets for cleaning up resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,28 +239,31 @@ This pattern ensures that syncs are efficient and can be run frequently to keep 
 
 ## Available Just Commands
 
-The `justfile` provides several commands to streamline development and deployment:
+The `justfile` provides several commands to streamline development and deployment. Commands are organized by their prefix:
 
-### Local Development
+### Local Development (no prefix)
 - `just run` - Run the sync once locally (auto-creates venv)
 - `just run-scheduled` - Run the sync on a schedule locally (auto-creates venv)
 - `just validate-all` - Run all validation scripts
-- `just clean` - Clean up temporary files
+- `just clean` - Clean up local development resources (including Docker)
 
-### Docker Commands
+### Docker Commands (docker- prefix)
 - `just docker-build` - Build the Docker image
 - `just docker-run` - Run the container locally
 - `just docker-stop` - Stop the container
 - `just docker-logs` - View container logs
 - `just docker-clean` - Clean up Docker resources
 
-### AWS Lambda Commands
-- `just terraform-init` - Initialize Terraform
+### AWS Lambda Commands (lambda- prefix)
 - `just lambda-deploy` - Build and deploy the Lambda function
 - `just lambda-invoke` - Manually trigger the Lambda function
-- `just lambda-logs` - View Lambda logs
+- `just lambda-logs` - View Lambda logs in real-time
+- `just lambda-logs-recent [minutes]` - View recent Lambda logs (default: last 30 minutes)
 - `just lambda-image` - View Lambda container image details
-- `just lambda-update` - Update Lambda configuration
+- `just lambda-destroy` - Safely destroy all AWS infrastructure
+
+### Master Commands
+- `just destroy-all` - Clean up everything (local resources including Docker, and AWS infrastructure)
 
 ## Monitoring
 


### PR DESCRIPTION
This PR adds destroy targets to the justfile for safely cleaning up resources across all environments:

- Added clean target for local development resources
- Added docker-clean target for Docker resources
- Added lambda-destroy target for AWS infrastructure
- Added destroy-all master target that cleans up everything
- Updated README with new targets and naming conventions
- Added clear completion messages to lambda-deploy target

The commands follow a consistent naming convention:
- Local development: no prefix (e.g., clean)
- Docker: docker- prefix (e.g., docker-clean)
- AWS Lambda: lambda- prefix (e.g., lambda-destroy)
- Master commands: descriptive names (e.g., destroy-all)

Each environment has its own cleanup command, and destroy-all provides a way to clean everything at once.

Closes #1